### PR TITLE
feat(storybook): add searchable sidebar and deep-link routing support

### DIFF
--- a/crates/nemo-storybook-generator/src/lib.rs
+++ b/crates/nemo-storybook-generator/src/lib.rs
@@ -298,7 +298,49 @@ pub fn generate_storybook_xml() -> String {
 
     out.push_str("      </stack>\n");
     out.push_str("    </stack>\n");
-    out.push_str("  </layout>\n");
+    out.push_str("  </layout>\n\n");
+
+    // Collect all component names for the script section
+    let all_names: Vec<String> = {
+        let mut names = Vec::new();
+        for cat in CATEGORIES {
+            let mut comps = registry.list_by_category(cat.clone());
+            comps.sort_by(|a, b| a.name.cmp(&b.name));
+            for comp in comps {
+                names.push(comp.name.clone());
+            }
+        }
+        names
+    };
+
+    let page_ids_json = all_names
+        .iter()
+        .map(|n| format!("\"page_{}\"", n))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let comp_names_json = all_names
+        .iter()
+        .map(|n| format!("\"{}\"", n))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    out.push_str("  <script lang=\"rhai\"><![CDATA[\n");
+    out.push_str(&format!("    let PAGE_IDS = [{}];\n", page_ids_json));
+    out.push_str(&format!("    let COMPONENT_NAMES = [{}];\n\n", comp_names_json));
+    out.push_str("    fn navigate_to(component_name) {\n");
+    out.push_str("        for id in PAGE_IDS {\n");
+    out.push_str("            set_component_property(id, \"visible\", id == \"page_\" + component_name);\n");
+    out.push_str("        }\n");
+    out.push_str("    }\n\n");
+    out.push_str("    fn on_search_change(value) {\n");
+    out.push_str("        for name in COMPONENT_NAMES {\n");
+    out.push_str("            let btn_id = \"nav_\" + name;\n");
+    out.push_str("            let visible = value == \"\" || name.contains(value);\n");
+    out.push_str("            set_component_property(btn_id, \"visible\", visible);\n");
+    out.push_str("        }\n");
+    out.push_str("    }\n");
+    out.push_str("  ]]></script>\n");
+
     out.push_str("</nemo>\n");
     out
 }

--- a/crates/nemo/src/main.rs
+++ b/crates/nemo/src/main.rs
@@ -286,9 +286,12 @@ fn launch_storybook(sb_args: &args::StorybookArgs, args: &Args) -> Result<()> {
     let initial_component = sb_args.component.clone();
     let initial_search = sb_args.search.clone();
 
-    // Store search term for workspace to pick up
+    // Store component and search terms as env vars for the runtime to pick up
     if let Some(ref search) = initial_search {
         env::set_var("NEMO_STORYBOOK_SEARCH", search);
+    }
+    if let Some(ref comp) = initial_component {
+        env::set_var("NEMO_STORYBOOK_COMPONENT", comp);
     }
 
     // Launch the app with the storybook config


### PR DESCRIPTION
Closes #52

## Summary
- Generator enhanced with a Rhai script section containing `navigate_to()` and `on_search_change()` for sidebar filtering and component navigation
- All nav buttons have `id="nav_{name}"` and all pages have `id="page_{name}"` for script targeting
- `launch_storybook()` passes `--component` and `--search` values via env vars (`NEMO_STORYBOOK_COMPONENT`, `NEMO_STORYBOOK_SEARCH`) into the launched app
- Sidebar search input (`id="sidebar_search"`) is wired in the generated XML

Depends on #51. Part of epic #9.