### PR TITLE
fix: validate --app-config path early with clear error

### DIFF
--- a/crates/nemo/src/main.rs
+++ b/crates/nemo/src/main.rs
@@ -54,6 +54,32 @@ fn main() -> Result<()> {
     // Load NemoConfig (config.toml)
     let nemo_config = NemoConfig::load_from(args.config.as_ref());
 
+    // Validate app_config path early so we fail fast with a clear message
+    // before any subsystem (runtime, recent-projects, etc.) tries to use it.
+    if let Some(ref app_config) = args.app_config {
+        // For relative paths, resolution against the current directory is
+        // implicit in Path::exists/is_file. If current_dir() fails we can
+        // still check the path as supplied; either way the error message
+        // shows the original path the user passed.
+        let resolved = if app_config.is_relative() {
+            match std::env::current_dir() {
+                Ok(cwd) => cwd.join(app_config),
+                Err(_) => app_config.clone(),
+            }
+        } else {
+            app_config.clone()
+        };
+
+        if !resolved.exists() {
+            eprintln!("Error: config file not found: {}", app_config.display());
+            std::process::exit(1);
+        }
+        if !resolved.is_file() {
+            eprintln!("Error: config path is not a file: {}", app_config.display());
+            std::process::exit(1);
+        }
+    }
+
     // If app_config is provided via CLI/env, handle headless/validate modes
     if let Some(ref app_config) = args.app_config {
         if args.headless || args.validate_only {


### PR DESCRIPTION
Closes #42.

When an invalid `--app-config` (or `NEMO_APP_CONFIG`) path is passed, the failure currently surfaces deep in the loading pipeline as a generic IO error. This adds a targeted check in `crates/nemo/src/main.rs` right after `Args::parse()`, before `runtime::NemoRuntime::new(...)` and the GPUI early-runtime path, so the user sees what they actually passed.

Behavior:

- Relative paths are resolved against `std::env::current_dir()` for the `exists`/`is_file` checks. If `current_dir()` fails the path is checked as supplied — the not-found error then reports the original path the user passed, never a canonicalized variant.
- Non-existent paths are never canonicalized.
- Error messages match the issue spec exactly:
  - `Error: config file not found: <path>`
  - `Error: config path is not a file: <path>`
  - followed by `std::process::exit(1)`.

The existing `if let Some(ref app_config) = args.app_config { ... headless/validate ... }` block is left intact; the new block is additive and only changes behavior for paths that would have failed anyway.

Verified with `cargo check -p nemo` and `cargo clippy -p nemo --no-deps` (clean).
